### PR TITLE
fix: Sanitize ChildLogger prefix to prevent log injection (CodeQL ale…

### DIFF
--- a/packages/engine-core/src/logger.ts
+++ b/packages/engine-core/src/logger.ts
@@ -216,7 +216,9 @@ class BrepFlowLogger {
   }
 
   public createChild(prefix: string, context?: LogContext): ChildLogger {
-    return new ChildLogger(this, prefix, context);
+    // Sanitize prefix to prevent log injection attacks via child logger prefix
+    const sanitizedPrefix = this.sanitizeForLogging(prefix);
+    return new ChildLogger(this, sanitizedPrefix, context);
   }
 }
 


### PR DESCRIPTION
…rt #71)

Addresses CodeQL security alert #71 (js/log-injection) by sanitizing the prefix parameter when creating child loggers. This prevents attackers from forging log entries via malicious prefixes containing control characters, newlines, or ANSI escape sequences.

Changes:
- Modified createChild() to sanitize prefix before ChildLogger creation
- Uses existing sanitizeForLogging() method for consistent protection
- Prevents log injection via child logger prefix concatenation

Security impact:
- Mitigates log forgery attacks
- Prevents terminal manipulation via ANSI codes in prefixes
- Blocks newline injection in log entries