### PR TITLE
ci: remove stale PNPM_VERSION (unblocks CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   NODE_VERSION: '20.11.1'
-  PNPM_VERSION: '8.6.7'
 
 jobs:
   lint:
@@ -18,8 +17,6 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
 
       - uses: actions/setup-node@v6
         with:
@@ -43,8 +40,6 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
 
       - uses: actions/setup-node@v6
         with:
@@ -65,8 +60,6 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
 
       - uses: actions/setup-node@v6
         with:
@@ -104,8 +97,6 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
 
       - uses: actions/setup-node@v6
         with:
@@ -148,8 +139,6 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   NODE_VERSION: '20.11.1'
-  PNPM_VERSION: '8.6.7'
 
 jobs:
   e2e-tests:
@@ -21,8 +20,6 @@ jobs:
 
     - name: Install pnpm
       uses: pnpm/action-setup@v4
-      with:
-        version: ${{ env.PNPM_VERSION }}
 
     - name: Setup Node.js
       uses: actions/setup-node@v6
@@ -106,8 +103,6 @@ jobs:
 
     - name: Install pnpm
       uses: pnpm/action-setup@v4
-      with:
-        version: ${{ env.PNPM_VERSION }}
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile
@@ -147,8 +142,6 @@ jobs:
 
     - name: Install pnpm
       uses: pnpm/action-setup@v4
-      with:
-        version: ${{ env.PNPM_VERSION }}
 
     - name: Install dependencies
       run: pnpm install --frozen-lockfile

--- a/.github/workflows/nightly-cli.yml
+++ b/.github/workflows/nightly-cli.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   NODE_VERSION: '20.11.1'
-  PNPM_VERSION: '8.6.7'
 
 jobs:
   cli-smoke:
@@ -17,8 +16,6 @@ jobs:
       - uses: actions/checkout@v5
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: ${{ env.PNPM_VERSION }}
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
Workflows declared PNPM_VERSION='8.6.7' while package.json has packageManager: pnpm@9.15.0. pnpm/action-setup@v4 errors when both are set (Multiple versions of pnpm specified). Dropping the env var + every with.version: block lets packageManager be authoritative. Unblocks lint / unit / e2e / docker jobs on every PR. Same pattern landed on phyne-crm #4, coforma-studio #35. 🤖 Claude Code