### PR TITLE
feat(k8s): add production manifests for cluster deployment

### DIFF
--- a/infra/k8s/production/kustomization.yaml
+++ b/infra/k8s/production/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: sim4d
+
+resources:
+  - namespace.yaml
+  - studio-deployment.yaml
+  - studio-service.yaml
+  - network-policies.yaml
+
+images:
+  - name: ghcr.io/madfam-org/sim4d-studio
+    newName: ghcr.io/madfam-org/sim4d-studio
+    newTag: latest

--- a/infra/k8s/production/namespace.yaml
+++ b/infra/k8s/production/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sim4d
+  labels:
+    app.kubernetes.io/part-of: madfam-platform
+    enclii.dev/type: application

--- a/infra/k8s/production/network-policies.yaml
+++ b/infra/k8s/production/network-policies.yaml
@@ -1,0 +1,58 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: sim4d
+spec:
+  podSelector: {}
+  policyTypes: [Ingress, Egress]
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-cloudflared-to-studio
+  namespace: sim4d
+spec:
+  podSelector:
+    matchLabels:
+      app: sim4d-studio
+  policyTypes: [Ingress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: cloudflare-tunnel
+      ports:
+        - protocol: TCP
+          port: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress-dns-https
+  namespace: sim4d
+spec:
+  podSelector: {}
+  policyTypes: [Egress]
+  egress:
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except: [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16]
+      ports:
+        - protocol: TCP
+          port: 443
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: data
+      ports:
+        - protocol: TCP
+          port: 5432

--- a/infra/k8s/production/secrets-template.yaml
+++ b/infra/k8s/production/secrets-template.yaml
@@ -1,0 +1,39 @@
+# Sim4D Secrets Template — NEVER commit with real values.
+#
+# Bootstrap (operator runs once per cluster):
+#   SESSION_SECRET=$(openssl rand -hex 32)
+#   kubectl create secret generic sim4d-secrets --namespace=sim4d \
+#     --from-literal=NODE_ENV=production \
+#     --from-literal=SESSION_SECRET="$SESSION_SECRET" \
+#     --from-literal=ALLOWED_ORIGINS=https://sim4d.io \
+#     --from-literal=TIMESCALE_URL="postgresql://sim4d:<PW>@postgres.data.svc.cluster.local:5432/sim4d" \
+#     --from-literal=JANUA_ISSUER=https://auth.madfam.io \
+#     --from-literal=JANUA_AUDIENCE=sim4d \
+#     --from-literal=JANUA_CLIENT_ID=sim4d \
+#     --from-literal=JANUA_CLIENT_SECRET="<from Janua admin>" \
+#     --from-literal=JANUA_JWKS_URI=https://auth.madfam.io/.well-known/jwks.json \
+#     --from-literal=R2_ENDPOINT="https://<acct>.r2.cloudflarestorage.com" \
+#     --from-literal=R2_ACCESS_KEY_ID="<from R2 console>" \
+#     --from-literal=R2_SECRET_ACCESS_KEY="<from R2 console>" \
+#     --from-literal=R2_BUCKET=sim4d-simulations
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sim4d-secrets
+  namespace: sim4d
+type: Opaque
+stringData:
+  NODE_ENV: "production"
+  SESSION_SECRET: ""
+  ALLOWED_ORIGINS: "https://sim4d.io"
+  TIMESCALE_URL: "postgresql://sim4d:<PASSWORD>@postgres.data.svc.cluster.local:5432/sim4d"
+  JANUA_ISSUER: "https://auth.madfam.io"
+  JANUA_AUDIENCE: "sim4d"
+  JANUA_CLIENT_ID: "sim4d"
+  JANUA_CLIENT_SECRET: ""
+  JANUA_JWKS_URI: "https://auth.madfam.io/.well-known/jwks.json"
+  R2_ENDPOINT: ""
+  R2_ACCESS_KEY_ID: ""
+  R2_SECRET_ACCESS_KEY: ""
+  R2_BUCKET: "sim4d-simulations"

--- a/infra/k8s/production/studio-deployment.yaml
+++ b/infra/k8s/production/studio-deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sim4d-studio
+  namespace: sim4d
+  labels:
+    app: sim4d-studio
+    app.kubernetes.io/name: sim4d-studio
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/part-of: madfam-platform
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: sim4d-studio
+  template:
+    metadata:
+      labels:
+        app: sim4d-studio
+        app.kubernetes.io/name: sim4d-studio
+        app.kubernetes.io/part-of: madfam-platform
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
+      imagePullSecrets:
+        - name: ghcr-credentials
+      containers:
+        - name: studio
+          image: ghcr.io/madfam-org/sim4d-studio:latest
+          ports:
+            - containerPort: 80
+          envFrom:
+            - secretRef:
+                name: sim4d-secrets
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+            limits:
+              cpu: 1000m
+              memory: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+              add: [NET_BIND_SERVICE]
+          startupProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 3
+            periodSeconds: 3
+            failureThreshold: 30
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            periodSeconds: 30
+          volumeMounts:
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /var/run
+      volumes:
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}

--- a/infra/k8s/production/studio-service.yaml
+++ b/infra/k8s/production/studio-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sim4d-studio
+  namespace: sim4d
+spec:
+  selector:
+    app: sim4d-studio
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+  type: ClusterIP


### PR DESCRIPTION
## Summary
MVP manifest set to land sim4d-studio on the MADFAM K3s cluster under \`sim4d.io\`. Just the primary studio frontend — all heavier services (marketing, collaboration, CI) scoped for follow-ups.

## Decisions vs \`.enclii.yml\`
- **Studio = static-build + nginx on :80** — OCCT.wasm runs client-side, pod is stateless. Assumes prod-ified \`Dockerfile.studio\` (\`vite build\` + nginx serve). Current Dockerfile runs \`vite\` dev mode; prod-ifying is a follow-up.
- **100Gi \`simulation-cache\` PVC dropped** — declared \`storageClassName: hetzner-ssd\` which doesn't exist on K3s (Longhorn-only). Simulation artifacts belong in R2; no server-side scratch needed.
- **Autoscaling + SLO dropped** — replicas=2 for MVP; HPA added once metrics-server targets are defined.
- **DB + R2 + Janua surfaces preserved** — \`TIMESCALE_URL\`, \`R2_{ENDPOINT,ACCESS_KEY_ID,SECRET_ACCESS_KEY,BUCKET}\`, \`JANUA_*\`, all wired via \`sim4d-secrets\`.
- **Postgres is shared \`data/postgres\`** — just restored from 14h outage (#102-106 on enclii). Migrate to dedicated if scaling pressure emerges.

## Files
\`namespace.yaml\`, \`kustomization.yaml\`, \`studio-deployment.yaml\`, \`studio-service.yaml\`, \`secrets-template.yaml\`, \`network-policies.yaml\`

## Operator actions
1. Prod-ify \`Dockerfile.studio\` so \`ghcr.io/madfam-org/sim4d-studio\` is actually a nginx-served Vite build.
2. Create sim4d database in shared Postgres (\`CREATE DATABASE sim4d\`) + user with credentials.
3. Bootstrap \`sim4d-secrets\` per the header in \`secrets-template.yaml\`.
4. Copy \`ghcr-credentials\` imagePullSecret into the \`sim4d\` namespace.
5. CI workflow to build+cosign-sign+push the studio image and patch the digest.
6. ArgoCD \`Application\` pointing at \`infra/k8s/production/\`.
7. Cloudflare tunnel route: \`sim4d.io\` → \`sim4d-studio.sim4d.svc.cluster.local:80\`.

## Test plan
- [x] \`kubectl kustomize infra/k8s/production/\` produces valid manifests
- [ ] Prod-ified Dockerfile passes build
- [ ] Studio pod passes startup probe against \`/\`
- [ ] \`https://sim4d.io\` serves the Vite app through the tunnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)