### PR TITLE
feat(ci): add enclii-build workflow for K8s deploys

### DIFF
--- a/.github/workflows/enclii-build.yml
+++ b/.github/workflows/enclii-build.yml
@@ -1,0 +1,114 @@
+name: Enclii build & publish
+
+# GitOps flow: push → build studio image → cosign sign → push to GHCR → commit
+# digest to infra/k8s/production/kustomization.yaml → ArgoCD auto-syncs.
+#
+# Image: ghcr.io/madfam-org/sim4d-studio:<sha>
+# Follows the MADFAM internal-devops pattern (routecraft / madlab / karafiel).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/studio/**'
+      - 'packages/**'
+      - 'Dockerfile.studio'
+      - 'infra/k8s/production/**'
+      - '.github/workflows/enclii-build.yml'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
+jobs:
+  build:
+    name: Build studio
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+        with:
+          cosign-release: 'v2.2.3'
+
+      - name: Build & push image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.studio
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          tags: |
+            ghcr.io/madfam-org/sim4d-studio:${{ github.sha }}
+            ghcr.io/madfam-org/sim4d-studio:main
+          labels: |
+            org.opencontainers.image.source=https://github.com/madfam-org/sim4d
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha,scope=studio
+          cache-to: type=gha,mode=max,scope=studio
+
+      - name: Sign image (keyless, Fulcio/Rekor)
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          cosign sign --yes "ghcr.io/madfam-org/sim4d-studio@${{ steps.build.outputs.digest }}"
+
+  update-manifest:
+    name: Commit digest to kustomization.yaml
+    needs: build
+    if: needs.build.result == 'success'
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.ENCLII_DEPLOY_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Install kustomize
+        run: |
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          sudo mv kustomize /usr/local/bin/
+
+      - name: Pin digest
+        run: |
+          cd infra/k8s/production
+          kustomize edit set image "ghcr.io/madfam-org/sim4d-studio=ghcr.io/madfam-org/sim4d-studio@${{ needs.build.outputs.digest }}"
+
+      - name: Commit & push
+        run: |
+          git config user.name "sim4d-ci[bot]"
+          git config user.email "ci@sim4d.io"
+          if git diff --quiet infra/k8s/production/kustomization.yaml; then
+            echo "No digest change to commit."
+            exit 0
+          fi
+          git add infra/k8s/production/kustomization.yaml
+          git commit -m "ci: pin sim4d-studio digest from ${{ github.sha }}"
+          git push
+
+      - name: Notify enclii lifecycle
+        if: env.ENCLII_API_URL != ''
+        env:
+          ENCLII_API_URL: ${{ secrets.ENCLII_API_URL }}
+          ENCLII_DEPLOY_TOKEN: ${{ secrets.ENCLII_DEPLOY_TOKEN }}
+        run: |
+          curl -sS -X POST "$ENCLII_API_URL/v1/callbacks/lifecycle-event" \
+            -H "Authorization: Bearer $ENCLII_DEPLOY_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{"project":"sim4d","commit":"${{ github.sha }}","event":"image-digest-committed"}' || true


### PR DESCRIPTION
Builds sim4d-studio, cosign-signs, pushes to ghcr.io/madfam-org/sim4d-studio, pins digest in kustomization.yaml.

Note: `Dockerfile.studio` is currently `vite` dev mode; prod-ification (vite build + nginx) is a separate follow-up. This workflow will successfully push whatever the Dockerfile builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)