### PR TITLE
fix(k8s): add privileged:false + runAsNonRoot for Kyverno

### DIFF
--- a/infra/k8s/production/studio-deployment.yaml
+++ b/infra/k8s/production/studio-deployment.yaml
@@ -45,6 +45,8 @@ spec:
               memory: 1Gi
           securityContext:
             allowPrivilegeEscalation: false
+            privileged: false
+            runAsNonRoot: true
             capabilities:
               drop: [ALL]
               add: [NET_BIND_SERVICE]


### PR DESCRIPTION
Same as madlab + subtext. Prophylactic — will hit same admission error once sim4d Dockerfile builds and pod is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
