### PR TITLE
fix(cloud-services): whitelist UPDATE column names per table [AUDIT H10]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -243,3 +243,11 @@ types → schemas → engine-core → engine-occt → sdk → nodes-core → vie
 5. **Determinism**: All geometry operations must be deterministic for content-addressed caching
 6. **Memory Management**: LRU caches for meshes, worker restarts on memory pressure
 7. **Testing Philosophy**: Unit tests for logic, integration for workflows, E2E for user journeys
+
+## Known Issues — Audit 2026-04-23
+
+See `/Users/aldoruizluna/labspace/claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md` for the full ecosystem audit.
+
+- ~~**🟠 H10: Dynamic column names in UPDATE `setClause`**~~ — Fixed 2026-04-23: per-table allowlists (`UPDATABLE_USER_FIELDS`, `UPDATABLE_PROJECT_FIELDS`, `UPDATABLE_SHARE_LINK_FIELDS`) + `filterUpdatable` helper. Unknown keys (e.g. attacker-supplied `isAdmin`) are dropped with a console warn and never reach the SQL generator.
+- **🟡 a11y: missing `<html lang>`** — add to root layout.
+- **🟡 UI: `console.log` in production** — `hooks/useStudioAnalytics.ts:74`, `components/monitoring/MonitoringDashboard.tsx:267`. Gate on `NODE_ENV !== 'production'`.

--- a/packages/cloud-services/src/database/cloud-database-service.ts
+++ b/packages/cloud-services/src/database/cloud-database-service.ts
@@ -3,6 +3,12 @@
  * Data persistence and querying for Sim4D cloud services
  */
 
+/* eslint-disable max-lines --
+ * This service predates the 500-line cap and needs a focused refactor
+ * (separate user/project/share-link repositories). Tracking that as
+ * tech-debt outside the scope of audit 2026-04-23 H10 SQL-injection fix
+ * so the security change can ship without a drive-by rewrite. */
+
 import EventEmitter from 'events';
 import {
   ProjectId,
@@ -211,9 +217,17 @@ export class CloudDatabaseService extends EventEmitter {
     const setClause = [];
     const values = [];
 
-    for (const [key, value] of Object.entries(updates)) {
-      if (key === 'id') continue; // Don't update ID
-
+    const allowed = this.filterUpdatable(
+      updates,
+      CloudDatabaseService.UPDATABLE_USER_FIELDS,
+      'users'
+    );
+    if (allowed.length === 0) {
+      // Nothing legal to update — return current row rather than emitting
+      // a malformed `UPDATE users SET  WHERE id = ?`.
+      return (await this.getUserById(userId))!;
+    }
+    for (const [key, value] of allowed) {
       const dbKey = this.camelToSnake(key);
       setClause.push(`${dbKey} = ?`);
 
@@ -319,6 +333,11 @@ export class CloudDatabaseService extends EventEmitter {
     for (const [key, value] of Object.entries(updates)) {
       if (key === 'id') continue;
 
+      if (!CloudDatabaseService.UPDATABLE_PROJECT_FIELDS.has(key)) {
+        console.warn(`[cloud-database-service] Rejected unknown update key projects.${key}`);
+        continue;
+      }
+
       const dbKey = this.camelToSnake(key);
       setClause.push(`${dbKey} = ?`);
 
@@ -327,6 +346,10 @@ export class CloudDatabaseService extends EventEmitter {
       } else {
         values.push(value);
       }
+    }
+
+    if (setClause.length === 0) {
+      return (await this.getProjectById(projectId))!;
     }
 
     values.push(projectId);
@@ -472,9 +495,15 @@ export class CloudDatabaseService extends EventEmitter {
     const setClause = [];
     const values = [];
 
-    for (const [key, value] of Object.entries(updates)) {
-      if (key === 'id') continue;
-
+    const allowed = this.filterUpdatable(
+      updates,
+      CloudDatabaseService.UPDATABLE_SHARE_LINK_FIELDS,
+      'share_links'
+    );
+    if (allowed.length === 0) {
+      return (await this.getShareLink(shareId)) as ShareLink;
+    }
+    for (const [key, value] of allowed) {
       const dbKey = this.camelToSnake(key);
       setClause.push(`${dbKey} = ?`);
       values.push(value);
@@ -708,6 +737,74 @@ export class CloudDatabaseService extends EventEmitter {
    */
   private camelToSnake(str: string): string {
     return str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+  }
+
+  /**
+   * Per-table column allowlist for UPDATE operations (audit 2026-04-23 H10).
+   *
+   * Prepared-statement placeholders (`?`) only parameterize values, not
+   * identifiers. An attacker-controlled key in the PATCH body (for example
+   * `{ "isAdmin": true }`) would otherwise be snake_cased into
+   * `UPDATE users SET is_admin = ?` — a silent privilege escalation if the
+   * table has such a column, a SQL error leak otherwise.
+   *
+   * These sets list the camelCase client-facing keys that may reach the
+   * column-building loop. `id` is always rejected. Anything else is
+   * dropped silently with a log line.
+   */
+  private static readonly UPDATABLE_USER_FIELDS = new Set<string>([
+    'email',
+    'name',
+    'avatar',
+    'isEmailVerified',
+    'preferences',
+    'subscription',
+    'teams',
+    'lastLoginAt',
+  ]);
+
+  private static readonly UPDATABLE_PROJECT_FIELDS = new Set<string>([
+    'name',
+    'description',
+    'ownerId',
+    'teamId',
+    'visibility',
+    'collaborators',
+    'tags',
+    'thumbnail',
+    'lastModified',
+    'size',
+    'nodeCount',
+    'cloudMetadata',
+  ]);
+
+  private static readonly UPDATABLE_SHARE_LINK_FIELDS = new Set<string>([
+    'expiresAt',
+    'accessLevel',
+    'isPublic',
+    'allowAnonymous',
+    'maxUses',
+    'currentUses',
+    'isActive',
+  ]);
+
+  private filterUpdatable<T extends object>(
+    updates: Partial<T>,
+    allowed: ReadonlySet<string>,
+    tableName: string
+  ): Array<[string, unknown]> {
+    const out: Array<[string, unknown]> = [];
+    for (const [key, value] of Object.entries(updates)) {
+      if (key === 'id') continue;
+      if (!allowed.has(key)) {
+        // Dropping silently would hide bugs; logging helps catch client
+        // mistakes without 500-ing the request.
+        console.warn(`[cloud-database-service] Rejected unknown update key ${tableName}.${key}`);
+        continue;
+      }
+      out.push([key, value]);
+    }
+    return out;
   }
 
   private generateUserId(): UserId {


### PR DESCRIPTION
Audit 2026-04-23 finding H10. updateUser, updateProject, and
updateShareLink built `SET ${dbKey} = ?` directly from
camelCase-to-snake_case-converted client keys. Prepared-statement
placeholders only parameterize values — identifiers pass through
verbatim, so a PATCH body like `{ "isAdmin": true }` would be
translated to `UPDATE users SET is_admin = ?` and silently escalate
privileges if such a column ever exists (and surface the schema via
SQL errors otherwise).

Changes:
- Three static Set<string> allowlists on CloudDatabaseService:
  UPDATABLE_USER_FIELDS (8 keys, matches INSERT INTO users columns
  minus id/createdAt), UPDATABLE_PROJECT_FIELDS (12), and
  UPDATABLE_SHARE_LINK_FIELDS (7 — lifecycle-relevant columns only;
  immutable keys like projectId/createdBy are not permitted).
- filterUpdatable(updates, allowed, tableName) drops unknown keys
  with a console.warn (helps catch client-side typos without
  500-ing the request) and returns only the permitted [key, value]
  pairs.
- Each updateX method now short-circuits when the filtered list is
  empty rather than emitting malformed `UPDATE t SET  WHERE id = ?`.
- eslint-disable max-lines at top (file was already 749 lines;
  refactoring into per-table repos is separate tech-debt, called out
  explicitly in the disable comment).

Pre-existing tsc errors (missing type imports, DatabaseConnection
shape drift) are unchanged by this PR — only new symbols added.



## Test plan
- [ ] Local smoke — reproduce the audit scenario and confirm it's blocked.
- [ ] CI green on the branch.
- [ ] Review the audit file-line anchors in `claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md`.

Full audit: `claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
