### PR TITLE
fix(build): pnpm store cache mount to unblock studio image builds

### DIFF
--- a/Dockerfile.studio
+++ b/Dockerfile.studio
@@ -1,9 +1,18 @@
+# syntax=docker/dockerfile:1.7
 FROM node:22.12-bullseye
 
 # Install pnpm
 ENV PNPM_HOME=/root/.local/share/pnpm
 ENV PATH=$PNPM_HOME:$PATH
 RUN corepack enable && corepack prepare pnpm@8.6.7 --activate
+
+# Configure pnpm to keep its store inside the BuildKit cache mount
+# below — without this, pnpm hard-link-fallback materializes copies
+# inside /app on every build and the engine-occt + viewport packages
+# blow past default ubuntu-latest runner memory pressure (exit 254 at
+# install time). Cache mount keeps the store on tmpfs/cache layer and
+# only the linked outputs land in the image.
+RUN pnpm config set store-dir /pnpm-store
 
 WORKDIR /app
 
@@ -17,8 +26,14 @@ COPY apps/studio ./apps/studio
 COPY config ./config
 COPY scripts ./scripts
 
-# Install dependencies
-RUN pnpm install --frozen-lockfile
+# Install dependencies — `--mount=type=cache` keeps the pnpm store
+# across builds, drastically reducing both install time and the
+# peak-memory footprint that was OOM-ing ubuntu-latest runners
+# (sim4d enclii-build.yml run 24868316640 onward, 2026-04-18+).
+# `sharing=locked` serializes concurrent builds so the store doesn't
+# corrupt under matrix parallelism.
+RUN --mount=type=cache,id=sim4d-pnpm-store,target=/pnpm-store,sharing=locked \
+    pnpm install --frozen-lockfile
 
 # Build dependencies (types, engine-core, etc.)
 RUN pnpm --filter @sim4d/types run build


### PR DESCRIPTION
## Summary

Sim4d-studio's image hasn't published in 14+ days. Every \`enclii-build.yml\` run since 2026-04-18 fails at:

\`\`\`
#15 [10/16] RUN pnpm install --frozen-lockfile
#15 4.957 Lockfile is up to date, resolution step is skipped
#15 ERROR: process "/bin/sh -c pnpm install --frozen-lockfile" did not complete successfully: exit code: 254
\`\`\`

Exit 254 after "resolution step is skipped" is the canonical **OOM-shaped failure** for default ubuntu-latest GHA runners (16 GB RAM / ~14 GB free disk). \`engine-occt\` is OCCT WASM bindings (large package set), and pnpm's hard-link fallback was materializing copies of every workspace dep into \`/app\`, hitting both disk and RSS pressure during the post-resolution write phase.

## Fix

Three small changes to \`Dockerfile.studio\`:

1. Add \`# syntax=docker/dockerfile:1.7\` so BuildKit cache mounts are honored.
2. Relocate the pnpm store off \`/app\` via \`pnpm config set store-dir /pnpm-store\`.
3. Mount the install step with \`--mount=type=cache,target=/pnpm-store,sharing=locked\` so the store persists across builds and writes land outside the image's RW layer.

## Test plan

- [ ] Push triggers \`enclii-build.yml\`. Expect \`Build studio\` to go green for the first time in 14 days.
- [ ] After image lands at \`ghcr.io/madfam-org/sim4d-studio:latest\`, ArgoCD picks up and \`sim4d/sim4d-studio\` deployment resolves from ImagePullBackOff (kustomization.yaml currently pins to \`:latest\`; that's a separate Kyverno hygiene item tracked in RFC 0017).

## Out of scope

- Migration off \`:latest\` tag in \`infra/k8s/production/kustomization.yaml\` — separate digest-pin sweep.
- Larger ARC runner pool — the cache mount alone may close the gap; if not, switch to a memory-tier runner is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)