### PR TITLE
fix(networkpolicy): drop ports restriction from allow-cloudflared-ingress

### DIFF
--- a/infra/k8s/production/network-policies.yaml
+++ b/infra/k8s/production/network-policies.yaml
@@ -7,6 +7,9 @@ spec:
   podSelector: {}
   policyTypes: [Ingress, Egress]
 ---
+# Cloudflared is the trust boundary — explicit per-port allowlists
+# silently drop traffic on every containerPort change. See
+# status.enclii.dev incident 2026-05-04.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -22,9 +25,6 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: cloudflare-tunnel
-      ports:
-        - protocol: TCP
-          port: 80
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy


### PR DESCRIPTION
## Context

On 2026-05-04, status.enclii.dev showed 4 outages caused by the same class of bug: the `allow-cloudflared-ingress` NetworkPolicy explicitly listed pod ports, but Kubernetes NetworkPolicy `ports` evaluates the **destination pod containerPort** — not the Service port. Whenever a Deployment's `containerPort` differs from what the policy allows (e.g. nginx-unprivileged binding 8080 instead of 80, or a Next.js standalone server moving from 3000 to a custom port), traffic gets silently dropped at the CNI layer.

Same trust boundary, different containerPort — same outage, every quarter.

## Fix

Drop the `ports:` field entirely from `allow-cloudflared-ingress`. Cloudflared *is* the trust boundary; restricting which pod ports it can reach adds zero security (anything that reaches cloudflared is already authenticated upstream by Cloudflare Access / Tunnel ACLs / our application auth) but creates this exact silent-drop failure mode.

## No-op for runtime traffic

- Same trust boundary (cloudflare-tunnel namespace)
- Same `from:` selector (cloudflared pod)
- **Zero new ingress paths** — only cloudflared can reach pods in this namespace, just like before
- Removes the per-containerPort tripwire that has cost us 4 outages today

## Verification

- `kubectl --dry-run=client apply` passes
- YAML lints clean
