### PR TITLE
feat(security): allow Selva Atrium to iframe this app via CSP frame-ancestors

### DIFF
--- a/claudedocs/PENDING_CSP_ATRIUM.md
+++ b/claudedocs/PENDING_CSP_ATRIUM.md
@@ -1,0 +1,39 @@
+# PENDING — feat(security): allow Selva Atrium to iframe this app via CSP frame-ancestors
+
+This commit lands the patch description only. The actual code changes are
+parked in `claudedocs/PENDING_CSP_ATRIUM.patch` because the repo's
+`pre-commit` hook (lint-staged → `eslint --fix`) fails on **pre-existing**
+errors in unrelated code:
+
+- `apps/studio/vite.config.production.ts` — 3× `no-secrets/no-secrets`
+  false positives on `process.env.ENABLE_MOCK_GEOMETRY` etc. (entropy 4.13)
+- `apps/studio/vite.config.ts` — `no-secrets/no-secrets` on a docs path
+  string + `complexity` (23 vs max 15) on `manualChunks`
+- `tests/security/csp-enforcement.test.ts` — `max-lines-per-function`
+  (282 vs 100) + 3× `max-nested-callbacks` (4 vs 3) — all outside the
+  block this change touches
+
+Per the rollout ticket, `--no-verify` is **not used**. Operator action
+needed: either bump the rule allowances for these specific lines, or
+allow a one-time bypass for the CSP rollout.
+
+## Apply the patch from repo root
+
+```bash
+git apply claudedocs/PENDING_CSP_ATRIUM.patch
+```
+
+## What the patch does
+
+Permits the Selva Atrium (selva-office consumer feature) to iframe the
+Studio across all three CSP emission points (dev server, preview server,
+production server) and updates the contract test that previously asserted
+`frame-ancestors: 'none'`. `X-Frame-Options` downgraded from `DENY` to
+`SAMEORIGIN` as a legacy fallback.
+
+```
+frame-ancestors 'self' https://selva.town https://*.selva.town https://*.madfam.io
+```
+
+Same operator (Innovaciones MADFAM) on both Selva and Sim4D — no
+third-party trust boundary is being relaxed.

--- a/claudedocs/PENDING_CSP_ATRIUM.patch
+++ b/claudedocs/PENDING_CSP_ATRIUM.patch
@@ -1,0 +1,117 @@
+diff --git a/apps/studio/vite.config.production.ts b/apps/studio/vite.config.production.ts
+index f7154185..c49661c2 100644
+--- a/apps/studio/vite.config.production.ts
++++ b/apps/studio/vite.config.production.ts
+@@ -50,11 +50,15 @@ export default defineConfig({
+       'Cross-Origin-Opener-Policy': 'same-origin',
+       'Cross-Origin-Embedder-Policy': 'require-corp',
+       // Security headers
++      // X-Frame-Options downgraded from DENY to SAMEORIGIN as a legacy fallback for
++      // the Selva Atrium iframe pattern; modern browsers honor frame-ancestors below.
+       'X-Content-Type-Options': 'nosniff',
+-      'X-Frame-Options': 'DENY',
++      'X-Frame-Options': 'SAMEORIGIN',
+       'X-XSS-Protection': '1; mode=block',
+       'Referrer-Policy': 'strict-origin-when-cross-origin',
+       // CSP for production
++      // frame-ancestors: allows the Selva Atrium (selva-office consumer feature)
++      // to embed the Studio. Same operator on both sides.
+       'Content-Security-Policy': [
+         "default-src 'self'",
+         "script-src 'self' 'wasm-unsafe-eval'",
+@@ -63,6 +67,7 @@ export default defineConfig({
+         "connect-src 'self' https://api.sim4d.com",
+         "worker-src 'self' blob:",
+         "frame-src 'none'",
++        "frame-ancestors 'self' https://selva.town https://*.selva.town https://*.madfam.io",
+         "object-src 'none'",
+         "base-uri 'self'",
+         "form-action 'self'",
+diff --git a/apps/studio/vite.config.ts b/apps/studio/vite.config.ts
+index 8d8b2136..8ba6b25c 100644
+--- a/apps/studio/vite.config.ts
++++ b/apps/studio/vite.config.ts
+@@ -158,6 +158,8 @@ export default defineConfig({
+       // SECURITY: Content Security Policy
+       // Note: 'unsafe-inline' is allowed in development for React Fast Refresh (HMR)
+       // Production builds use strict CSP without inline scripts
++      // frame-ancestors: allows the Selva Atrium (selva-office consumer feature) to
++      // embed the Studio. Same operator (Innovaciones MADFAM) on both sides.
+       'Content-Security-Policy': [
+         "default-src 'self'",
+         "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'", // unsafe-inline required for React Fast Refresh in dev
+@@ -166,14 +168,16 @@ export default defineConfig({
+         "img-src 'self' data: blob:",
+         "font-src 'self' data:",
+         "connect-src 'self' ws: wss:", // WebSocket for dev server HMR
+-        "frame-ancestors 'none'",
++        "frame-ancestors 'self' https://selva.town https://*.selva.town https://*.madfam.io",
+         "base-uri 'self'",
+         "form-action 'self'",
+       ].join('; '),
+ 
+       // SECURITY: Additional security headers
++      // X-Frame-Options downgraded from DENY to SAMEORIGIN as a legacy fallback
++      // for the Selva Atrium iframe pattern; modern browsers honor frame-ancestors.
+       'X-Content-Type-Options': 'nosniff',
+-      'X-Frame-Options': 'DENY',
++      'X-Frame-Options': 'SAMEORIGIN',
+       'X-XSS-Protection': '1; mode=block',
+       'Referrer-Policy': 'strict-origin-when-cross-origin',
+       'Permissions-Policy': 'geolocation=(), microphone=(), camera=()',
+@@ -201,6 +205,7 @@ export default defineConfig({
+       'Cross-Origin-Embedder-Policy': 'require-corp',
+ 
+       // SECURITY: Content Security Policy (same as dev server)
++      // frame-ancestors: see dev server comment above — Selva Atrium allowance.
+       'Content-Security-Policy': [
+         "default-src 'self'",
+         "script-src 'self' 'wasm-unsafe-eval'",
+@@ -209,14 +214,14 @@ export default defineConfig({
+         "img-src 'self' data: blob:",
+         "font-src 'self' data:",
+         "connect-src 'self' ws: wss:",
+-        "frame-ancestors 'none'",
++        "frame-ancestors 'self' https://selva.town https://*.selva.town https://*.madfam.io",
+         "base-uri 'self'",
+         "form-action 'self'",
+       ].join('; '),
+ 
+       // SECURITY: Additional security headers
+       'X-Content-Type-Options': 'nosniff',
+-      'X-Frame-Options': 'DENY',
++      'X-Frame-Options': 'SAMEORIGIN',
+       'X-XSS-Protection': '1; mode=block',
+       'Referrer-Policy': 'strict-origin-when-cross-origin',
+       'Permissions-Policy': 'geolocation=(), microphone=(), camera=()',
+diff --git a/tests/security/csp-enforcement.test.ts b/tests/security/csp-enforcement.test.ts
+index 28842c8c..a73f4a52 100644
+--- a/tests/security/csp-enforcement.test.ts
++++ b/tests/security/csp-enforcement.test.ts
+@@ -106,12 +106,23 @@ describe('Content Security Policy (CSP)', () => {
+       expect(policy['connect-src']).toContain('wss:');
+     });
+ 
+-    it('should block frame embedding', () => {
++    it('should permit Selva Atrium and same-origin to embed (frame-ancestors)', () => {
++      // Selva Atrium (selva-office consumer feature) is permitted to iframe the
++      // Studio. Same operator owns both — no third-party trust boundary relaxed.
+       const policy = {
+-        'frame-ancestors': ["'none'"], // Prevent clickjacking
++        'frame-ancestors': [
++          "'self'",
++          'https://selva.town',
++          'https://*.selva.town',
++          'https://*.madfam.io',
++        ],
+       };
+ 
+-      expect(policy['frame-ancestors']).toContain("'none'");
++      expect(policy['frame-ancestors']).toContain("'self'");
++      expect(policy['frame-ancestors']).toContain('https://selva.town');
++      expect(policy['frame-ancestors']).toContain('https://*.selva.town');
++      expect(policy['frame-ancestors']).toContain('https://*.madfam.io');
++      expect(policy['frame-ancestors']).not.toContain("'none'");
+     });
+ 
+     it('should enable upgrade-insecure-requests', () => {


### PR DESCRIPTION
## ⚠️ BLOCKED on pre-existing pre-commit lint errors

This PR currently lands only `claudedocs/PENDING_CSP_ATRIUM.md` + the parked patch (`claudedocs/PENDING_CSP_ATRIUM.patch`). The real CSP changes are NOT applied yet because the repo's `pre-commit` hook (`lint-staged → eslint --fix`) fails on **pre-existing** errors in unrelated code that have nothing to do with this PR:

- `apps/studio/vite.config.production.ts` — 3× `no-secrets/no-secrets` flagging strings like `process.env.ENABLE_MOCK_GEOMETRY` (entropy 4.13 false positive)
- `apps/studio/vite.config.ts` — 1× `no-secrets/no-secrets` on a docs path string + 1× `complexity` (23 vs max 15) on `manualChunks`
- `tests/security/csp-enforcement.test.ts` — `max-lines-per-function` (282 vs 100) + 3× `max-nested-callbacks` (4 vs 3) — all pre-existing, outside the block this change touches

Per the rollout ticket, **`--no-verify` is not used**. Operator decision needed:
1. Add `// eslint-disable-next-line ...` comments / bump rule allowances on those pre-existing lines, then run `git apply claudedocs/PENDING_CSP_ATRIUM.patch` and re-commit, OR
2. Allow a one-time `--no-verify` for the CSP rollout commit, OR
3. Land a separate cleanup PR first that fixes the lint debt, then re-run this rollout.

## What the patched code does

Permits the **Selva Atrium** (selva-office consumer feature that surfaces every MADFAM platform as a window into a single welcoming central space) to iframe the Studio. Three CSP emission points + the contract test:

| Surface | File | Change |
|---|---|---|
| Dev server | `apps/studio/vite.config.ts` (`server.headers`) | `frame-ancestors 'none'` → Atrium allowance, `X-Frame-Options DENY` → `SAMEORIGIN` |
| Preview server | `apps/studio/vite.config.ts` (`preview.headers`) | same |
| Production server | `apps/studio/vite.config.production.ts` (`server.headers`) | adds `frame-ancestors` directive (was missing), `X-Frame-Options DENY` → `SAMEORIGIN` |
| Contract test | `tests/security/csp-enforcement.test.ts` | now asserts the Atrium allowance instead of `'none'` |

CSP value:

```
frame-ancestors 'self' https://selva.town https://*.selva.town https://*.madfam.io
```

## Auth-path clickjacking note

App-wide CSP. The Studio is a parametric CAD canvas with no authenticated user-session UI today; clickjacking surface is acceptable because Innovaciones MADFAM operates both Selva and Sim4D.

**DO NOT MERGE.**