### PR TITLE
fix(networkpolicy): widen allow-cloudflared selector to part-of label (prevent silent ingress drops on new pods)

### DIFF
--- a/infra/k8s/production/network-policies.yaml
+++ b/infra/k8s/production/network-policies.yaml
@@ -7,9 +7,20 @@ spec:
   podSelector: {}
   policyTypes: [Ingress, Egress]
 ---
-# Cloudflared is the trust boundary — explicit per-port allowlists
-# silently drop traffic on every containerPort change. See
-# status.enclii.dev incident 2026-05-04.
+# Public-facing pods accept ingress from the Cloudflare Tunnel only.
+#
+# Cloudflared is the trust boundary — explicit per-port allowlists silently
+# drop traffic on every containerPort change (see status.enclii.dev incident
+# 2026-05-04).
+#
+# The selector intentionally targets the `app.kubernetes.io/part-of: sim4d`
+# label rather than a single `app: sim4d-studio` value. Narrow per-app
+# selectors silently drop traffic the moment a new pod (e.g. a future
+# sim4d-api, sim4d-worker, or sim4d-admin) joins the namespace without
+# being added to the list. Selecting on the part-of label means every
+# sim4d-owned pod is automatically reachable from cloudflared, while the
+# namespace's `default-deny` policy still blocks any pod that does NOT
+# carry the sim4d part-of label.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -18,7 +29,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: sim4d-studio
+      app.kubernetes.io/part-of: sim4d
   policyTypes: [Ingress]
   ingress:
     - from:

--- a/infra/k8s/production/studio-deployment.yaml
+++ b/infra/k8s/production/studio-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app: sim4d-studio
     app.kubernetes.io/name: sim4d-studio
     app.kubernetes.io/component: frontend
-    app.kubernetes.io/part-of: madfam-platform
+    app.kubernetes.io/part-of: sim4d
 spec:
   replicas: 2
   selector:
@@ -18,7 +18,7 @@ spec:
       labels:
         app: sim4d-studio
         app.kubernetes.io/name: sim4d-studio
-        app.kubernetes.io/part-of: madfam-platform
+        app.kubernetes.io/part-of: sim4d
     spec:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
## Summary

The `allow-cloudflared-to-studio` NetworkPolicy targets only `app: sim4d-studio`. Any new sim4d pod (e.g. a future `sim4d-api`, `sim4d-worker`, or `sim4d-admin`) silently drops cloudflare-tunnel ingress at the CNI layer because the namespace's `default-deny` policy catches everything without a matching allow rule.

This was flagged by the May 4 ecosystem sweep agent — same root-cause class as the May 4 `status.enclii.dev` incidents: **anything new added breaks invisibly**.

## Bug class

The pattern across the ecosystem:
- A `default-deny-all` NetworkPolicy with selector `{}` (catch-all in namespace).
- A narrow `allow-cloudflared-*` NetworkPolicy with a per-`app` selector.
- New pods that don't match the narrow selector fail open at the cluster API but fail closed at the CNI — no error, no event, just dropped packets.

## Fix

- Widen `allow-cloudflared-to-studio.spec.podSelector` from `app: sim4d-studio` to `app.kubernetes.io/part-of: sim4d`.
- Update `studio-deployment.yaml` to carry `app.kubernetes.io/part-of: sim4d` on both the Deployment metadata and the pod template metadata. (Previously the value was `madfam-platform`, which is too broad to be a per-product cloudflared selector — it would have made the cloudflared allowlist match every MADFAM pod in the namespace, but no other pods exist here today, so it's a fresh per-product label.)
- Add an inline comment documenting the intent so future contributors don't re-narrow the selector.

## Relationship to #63

This PR is **independent of and complements** #63 (which drops the `ports:` field from the same NetworkPolicy). Both fixes are necessary:
- #63 prevents silent drops when a `containerPort` changes.
- This PR prevents silent drops when a new sibling pod is added to the namespace.

The diffs do not overlap — different fields of the same NetworkPolicy.

## Diff size

- 1 selector change (cloudflared NP)
- 2 label value changes (`madfam-platform` → `sim4d` on Deployment + pod template) on the existing `studio-deployment.yaml`
- 0 deployments needed a new label added (the `app.kubernetes.io/part-of` key was already present)

## Test plan

- [ ] Apply manifests in staging and confirm cloudflared can still reach `sim4d-studio` pods
- [ ] Add a temporary `sim4d-api` Deployment carrying `app.kubernetes.io/part-of: sim4d` and confirm cloudflared can reach it without further policy changes
- [ ] `kubectl describe networkpolicy -n sim4d allow-cloudflared-to-studio` shows the new selector