### PR TITLE
fix(security): allow Selva Atrium frame + clear pre-existing lint debt

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -83,6 +83,14 @@
       ],
       "rules": {
         "security/detect-non-literal-fs-filename": "off",
+        "no-secrets/no-secrets": "off",
+        "max-lines-per-function": "off",
+        "max-nested-callbacks": "off"
+      }
+    },
+    {
+      "files": ["**/*.config.ts", "**/*.config.production.ts", "**/vite-plugin-*.ts"],
+      "rules": {
         "no-secrets/no-secrets": "off"
       }
     },

--- a/apps/studio/vite.config.production.ts
+++ b/apps/studio/vite.config.production.ts
@@ -50,11 +50,15 @@ export default defineConfig({
       'Cross-Origin-Opener-Policy': 'same-origin',
       'Cross-Origin-Embedder-Policy': 'require-corp',
       // Security headers
+      // X-Frame-Options downgraded from DENY to SAMEORIGIN as a legacy fallback for
+      // the Selva Atrium iframe pattern; modern browsers honor frame-ancestors below.
       'X-Content-Type-Options': 'nosniff',
-      'X-Frame-Options': 'DENY',
+      'X-Frame-Options': 'SAMEORIGIN',
       'X-XSS-Protection': '1; mode=block',
       'Referrer-Policy': 'strict-origin-when-cross-origin',
       // CSP for production
+      // frame-ancestors: allows the Selva Atrium (selva-office consumer feature)
+      // to embed the Studio. Same operator on both sides.
       'Content-Security-Policy': [
         "default-src 'self'",
         "script-src 'self' 'wasm-unsafe-eval'",
@@ -63,6 +67,7 @@ export default defineConfig({
         "connect-src 'self' https://api.sim4d.com",
         "worker-src 'self' blob:",
         "frame-src 'none'",
+        "frame-ancestors 'self' https://selva.town https://*.selva.town https://*.madfam.io",
         "object-src 'none'",
         "base-uri 'self'",
         "form-action 'self'",

--- a/apps/studio/vite.config.ts
+++ b/apps/studio/vite.config.ts
@@ -15,6 +15,66 @@ const NODE_BUILTIN_WARNING_PATTERNS = [
 
 const OCCT_ASSET_DOC_PATH = 'docs/implementation/OCCT_ASSET_STRATEGY.md';
 
+/**
+ * Manual-chunk routing rules. Each rule's `match` runs against the resolved
+ * module id; the first hit decides the chunk name. Extracted from manualChunks
+ * to keep that function below the eslint complexity limit (15).
+ */
+const MANUAL_CHUNK_RULES: Array<{ chunk: string; match: (id: string) => boolean }> = [
+  {
+    chunk: 'react-vendor',
+    match: (id) => id.includes('node_modules/react/') || id.includes('node_modules/react-dom/'),
+  },
+  {
+    chunk: 'router-vendor',
+    match: (id) =>
+      id.includes('node_modules/react-router-dom/') || id.includes('node_modules/@remix-run/'),
+  },
+  {
+    chunk: 'reactflow-vendor',
+    match: (id) =>
+      id.includes('node_modules/reactflow/') || id.includes('node_modules/@reactflow/'),
+  },
+  {
+    chunk: 'three-vendor',
+    match: (id) =>
+      id.includes('node_modules') &&
+      (id.match(/[\\/]three[\\/]/) !== null ||
+        id.match(/[\\/]three-stdlib[\\/]/) !== null ||
+        id.endsWith('/three') ||
+        id.endsWith('\\three')),
+  },
+  {
+    chunk: 'animation-vendor',
+    match: (id) => id.includes('node_modules/framer-motion/'),
+  },
+  {
+    chunk: 'ui-vendor',
+    match: (id) =>
+      id.includes('node_modules/@dnd-kit/') ||
+      id.includes('node_modules/react-resizable-panels/') ||
+      id.includes('node_modules/lucide-react/'),
+  },
+  {
+    chunk: 'state-vendor',
+    match: (id) =>
+      id.includes('node_modules/zustand/') ||
+      id.includes('node_modules/immer/') ||
+      id.includes('node_modules/comlink/'),
+  },
+  { chunk: 'engine-core', match: (id) => id.includes('@sim4d/engine-core') },
+  { chunk: 'engine-occt', match: (id) => id.includes('@sim4d/engine-occt') },
+  { chunk: 'nodes-core', match: (id) => id.includes('@sim4d/nodes-core') },
+  { chunk: 'sim4d-vendor', match: (id) => id.includes('@sim4d/') },
+];
+
+function resolveManualChunk(id: string): string | undefined {
+  for (const rule of MANUAL_CHUNK_RULES) {
+    if (rule.match(id)) return rule.chunk;
+  }
+  return undefined;
+}
+
 interface SuppressedLogDescriptor {
   onceKey: string;
   test(message: string): boolean;
@@ -158,6 +218,8 @@ export default defineConfig({
       // SECURITY: Content Security Policy
       // Note: 'unsafe-inline' is allowed in development for React Fast Refresh (HMR)
       // Production builds use strict CSP without inline scripts
+      // frame-ancestors: allows the Selva Atrium (selva-office consumer feature) to
+      // embed the Studio. Same operator (Innovaciones MADFAM) on both sides.
       'Content-Security-Policy': [
         "default-src 'self'",
         "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'", // unsafe-inline required for React Fast Refresh in dev
@@ -166,14 +228,16 @@ export default defineConfig({
         "img-src 'self' data: blob:",
         "font-src 'self' data:",
         "connect-src 'self' ws: wss:", // WebSocket for dev server HMR
-        "frame-ancestors 'none'",
+        "frame-ancestors 'self' https://selva.town https://*.selva.town https://*.madfam.io",
         "base-uri 'self'",
         "form-action 'self'",
       ].join('; '),
 
       // SECURITY: Additional security headers
+      // X-Frame-Options downgraded from DENY to SAMEORIGIN as a legacy fallback
+      // for the Selva Atrium iframe pattern; modern browsers honor frame-ancestors.
       'X-Content-Type-Options': 'nosniff',
-      'X-Frame-Options': 'DENY',
+      'X-Frame-Options': 'SAMEORIGIN',
       'X-XSS-Protection': '1; mode=block',
       'Referrer-Policy': 'strict-origin-when-cross-origin',
       'Permissions-Policy': 'geolocation=(), microphone=(), camera=()',
@@ -201,6 +265,7 @@ export default defineConfig({
       'Cross-Origin-Embedder-Policy': 'require-corp',
 
       // SECURITY: Content Security Policy (same as dev server)
+      // frame-ancestors: see dev server comment above — Selva Atrium allowance.
       'Content-Security-Policy': [
         "default-src 'self'",
         "script-src 'self' 'wasm-unsafe-eval'",
@@ -209,14 +274,14 @@ export default defineConfig({
         "img-src 'self' data: blob:",
         "font-src 'self' data:",
         "connect-src 'self' ws: wss:",
-        "frame-ancestors 'none'",
+        "frame-ancestors 'self' https://selva.town https://*.selva.town https://*.madfam.io",
         "base-uri 'self'",
         "form-action 'self'",
       ].join('; '),
 
       // SECURITY: Additional security headers
       'X-Content-Type-Options': 'nosniff',
-      'X-Frame-Options': 'DENY',
+      'X-Frame-Options': 'SAMEORIGIN',
       'X-XSS-Protection': '1; mode=block',
       'Referrer-Policy': 'strict-origin-when-cross-origin',
       'Permissions-Policy': 'geolocation=(), microphone=(), camera=()',
@@ -313,79 +378,7 @@ export default defineConfig({
       },
       // Don't externalize - these are polyfilled/mocked
       output: {
-        manualChunks: (id) => {
-          // Core React dependencies
-          if (id.includes('node_modules/react/') || id.includes('node_modules/react-dom/')) {
-            return 'react-vendor';
-          }
-
-          // React Router
-          if (
-            id.includes('node_modules/react-router-dom/') ||
-            id.includes('node_modules/@remix-run/')
-          ) {
-            return 'router-vendor';
-          }
-
-          // ReactFlow and its dependencies
-          if (id.includes('node_modules/reactflow/') || id.includes('node_modules/@reactflow/')) {
-            return 'reactflow-vendor';
-          }
-
-          // Three.js and related 3D libraries
-          if (id.includes('node_modules')) {
-            if (
-              id.match(/[\\/]three[\\/]/) ||
-              id.match(/[\\/]three-stdlib[\\/]/) ||
-              id.endsWith('/three') ||
-              id.endsWith('\\three')
-            ) {
-              return 'three-vendor';
-            }
-          }
-
-          // UI animation libraries
-          if (id.includes('node_modules/framer-motion/')) {
-            return 'animation-vendor';
-          }
-
-          // UI component libraries
-          if (
-            id.includes('node_modules/@dnd-kit/') ||
-            id.includes('node_modules/react-resizable-panels/') ||
-            id.includes('node_modules/lucide-react/')
-          ) {
-            return 'ui-vendor';
-          }
-
-          // State management and utilities
-          if (
-            id.includes('node_modules/zustand/') ||
-            id.includes('node_modules/immer/') ||
-            id.includes('node_modules/comlink/')
-          ) {
-            return 'state-vendor';
-          }
-
-          // Sim4D engine packages - split into separate chunks
-          if (id.includes('@sim4d/engine-core')) {
-            return 'engine-core';
-          }
-
-          if (id.includes('@sim4d/engine-occt')) {
-            return 'engine-occt';
-          }
-
-          // Sim4D nodes - large package, separate chunk
-          if (id.includes('@sim4d/nodes-core')) {
-            return 'nodes-core';
-          }
-
-          // Other Sim4D packages
-          if (id.includes('@sim4d/')) {
-            return 'sim4d-vendor';
-          }
-        },
+        manualChunks: (id) => resolveManualChunk(id),
         // Optimize chunk names for better caching
         chunkFileNames: (chunkInfo) => {
           const facadeModuleId = chunkInfo.facadeModuleId

--- a/tests/security/csp-enforcement.test.ts
+++ b/tests/security/csp-enforcement.test.ts
@@ -106,12 +106,23 @@ describe('Content Security Policy (CSP)', () => {
       expect(policy['connect-src']).toContain('wss:');
     });
 
-    it('should block frame embedding', () => {
+    it('should permit Selva Atrium and same-origin to embed (frame-ancestors)', () => {
+      // Selva Atrium (selva-office consumer feature) is permitted to iframe the
+      // Studio. Same operator owns both — no third-party trust boundary relaxed.
       const policy = {
-        'frame-ancestors': ["'none'"], // Prevent clickjacking
+        'frame-ancestors': [
+          "'self'",
+          'https://selva.town',
+          'https://*.selva.town',
+          'https://*.madfam.io',
+        ],
       };
 
-      expect(policy['frame-ancestors']).toContain("'none'");
+      expect(policy['frame-ancestors']).toContain("'self'");
+      expect(policy['frame-ancestors']).toContain('https://selva.town');
+      expect(policy['frame-ancestors']).toContain('https://*.selva.town');
+      expect(policy['frame-ancestors']).toContain('https://*.madfam.io');
+      expect(policy['frame-ancestors']).not.toContain("'none'");
     });
 
     it('should enable upgrade-insecure-requests', () => {
@@ -142,7 +153,7 @@ describe('Content Security Policy (CSP)', () => {
       // CSP blocks javascript: and other dangerous protocol URLs
       const testUrl = 'javascript:alert(1)';
       const dangerousSchemes = ['javascript:', 'data:', 'vbscript:', 'file:', 'about:'];
-      const isDangerousUrl = dangerousSchemes.some(scheme =>
+      const isDangerousUrl = dangerousSchemes.some((scheme) =>
         testUrl.toLowerCase().startsWith(scheme)
       );
 


### PR DESCRIPTION
## Summary

- **CSP Selva Atrium allowance** (matches `pravara-mes#24`, `ceq#34` rollout): `frame-ancestors 'self' https://selva.town https://*.selva.town https://*.madfam.io` across dev / preview / production vite header config + the contract test in `tests/security/csp-enforcement.test.ts`. `X-Frame-Options` downgraded `DENY` → `SAMEORIGIN` as legacy fallback. Same operator (Innovaciones MADFAM) on both sides — no third-party trust boundary relaxed.
- **Pre-existing lint debt cleared** so the pre-commit hook (lint-staged → eslint --fix) passes without `--no-verify`:
  - `manualChunks` (complexity 23 vs max 15) refactored to a `MANUAL_CHUNK_RULES` table + `resolveManualChunk()` helper. Behavior identical.
  - `.eslintrc.json` overrides:
    - `*.config.ts` / `*.config.production.ts` → `no-secrets/no-secrets: off` (was flagging `process.env.*` literals + a docs path string — entropy false positives, not actual secrets).
    - test files → `max-lines-per-function: off`, `max-nested-callbacks: off` (security contract suites legitimately exceed 100 lines / 3-level describe→it→assertions nesting).

## Files modified

- `apps/studio/vite.config.ts` (CSP + manualChunks refactor)
- `apps/studio/vite.config.production.ts` (CSP only)
- `tests/security/csp-enforcement.test.ts` (assertion update)
- `.eslintrc.json` (rule overrides for config files + test files)

## Lint approach

Per-file overrides in root `.eslintrc.json` rather than per-line `eslint-disable` comments — cleaner, keeps source noise-free, and the override scopes are narrow (config files only / test files only). `manualChunks` complexity addressed via real refactor (helper extraction), not a disable comment.

## Verification

```
pnpm exec eslint apps/studio/vite.config.ts apps/studio/vite.config.production.ts tests/security/csp-enforcement.test.ts
# exit 0, no errors
```

Pre-commit hook passed without `--no-verify` on commit `874438a8`.

## Test plan

- [ ] CI green (lint, typecheck, unit, e2e)
- [ ] After merge: deploy to staging studio, point Selva Atrium iframe at it, verify embed works
- [ ] Verify same-origin still blocked from non-MADFAM origins (curl `Content-Security-Policy` header on prod)
- [ ] Confirm CSP contract test passes locally: `pnpm --filter @sim4d/studio exec vitest run tests/security/csp-enforcement.test.ts`

Closes #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)