### PR TITLE
docs: truthful current-status / stack congruency (RFC 0024 P3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ by **Innovaciones MADFAM** — a **MADFAM** company
 ## Why Sim4D?
 
 - **Vision:** a web-first, node-based CAD environment backed by OCCT so designers and automation pipelines share the same geometry kernel.
-- **Reality today:** production-ready interactive graph editor with real OCCT.wasm geometry backend, CLI tools, STEP/STL/IGES export, and comprehensive testing infrastructure (99.6% test pass rate).
-- **Roadmap:** see [docs/project/ROADMAP.md](docs/project/ROADMAP.md) for security hardening, code quality improvements, and ecosystem features (collaboration, plugins, marketplace).
+- **Reality today:** an **alpha** interactive graph editor with a real OCCT.wasm geometry backend, CLI tools, STEP/STL/IGES export, and a large test suite (see "Current status" below).
+- **Roadmap:** see [docs/project/ROADMAP.md](docs/project/ROADMAP.md) (last substantively updated **2025-11-18**) for security hardening, code quality improvements, and ecosystem features (collaboration, plugins, marketplace).
 
 If you come from OpenSCAD or Grasshopper, think of Sim4D as bringing that node-based workflow to the web with industrial-grade OCCT geometry.
 
@@ -28,9 +28,31 @@ If you come from OpenSCAD or Grasshopper, think of Sim4D as bringing that node-b
 
 ## Status
 
-**Production Ready · Real OCCT WASM Backend · Stable API**
+**Alpha · Real OCCT WASM Backend**
 
-✅ **Fully Operational**:
+### Current status (verified 2026-07-04)
+
+Sim4D is **alpha software**. An earlier version of this section claimed
+"Production Ready · Stable API" alongside the alpha label; that contradiction
+is resolved here in favor of the evidence:
+
+- Large monorepo: 15 packages + 2 apps (`studio`, `marketing`), ~4,800
+  tracked files, ~1,000 test/spec files.
+- Real, pre-compiled OCCT.wasm binaries ship in
+  `packages/engine-occt/wasm/` (web, single-thread, and Node builds) and
+  back both Studio and the CLI.
+- Heavy CI: 11 GitHub Actions workflows (unit/E2E/docker tests, quality
+  gate, security scan, production-readiness ratchet, container/Enclii
+  builds, nightly CLI).
+- Known gaps that keep this alpha: the generated ~1.8k-node catalogue is
+  disabled pending type fixes; `pnpm typecheck` fails in the collaboration
+  package; collaboration/marketplace/plugin ecosystem features are
+  incomplete; API stability is **not** guaranteed.
+
+The subsections below reflect the last detailed engineering snapshot
+(2025-11), kept for reference:
+
+✅ **Operational (as of 2025-11 snapshot)**:
 
 - Studio launches with complete OCCT WASM geometry backend (55MB compiled binaries)
 - All geometry operations verified: primitives, booleans, fillets, transformations
@@ -204,7 +226,7 @@ After setup you can:
 - `occt-core.wasm` (8.7MB) - Optimized single-thread web version
 - `occt-core.node.wasm` (8.3MB) - Node.js version for CLI
 
-**No compilation required** for standard use. WASM binaries are production-ready and verified.
+**No compilation required** for standard use. The WASM binaries are pre-compiled and verified against the core OCCT operation suite (the binaries are usable as-is; this is not a claim that the overall product is production-ready — see Status).
 
 > 📘 **Prerequisites:** See [docs/development/OCCT_BUILD_PREREQS.md](./docs/development/OCCT_BUILD_PREREQS.md) for required toolchains, environment variables, and expected outputs before invoking the build.
 
@@ -316,7 +338,7 @@ All project documentation is organized in the `docs/` directory:
 - **[API Reference](docs/technical/API.md)** - Complete API documentation
 - **[Setup Guide](docs/development/SETUP.md)** - Development environment setup
 - **[Contributing](docs/development/CONTRIBUTING.md)** - Contribution guidelines
-- **[Roadmap](docs/product/ROADMAP.md)** - Product roadmap and milestones
+- **[Roadmap](docs/project/ROADMAP.md)** - Product roadmap and milestones (last updated 2025-11-18)
 - **[Implementation Guides](docs/implementation/)** - Feature implementation details
 - **[Business Strategy](docs/business/)** - Go-to-market and business planning
 

--- a/docs/project/ROADMAP.md
+++ b/docs/project/ROADMAP.md
@@ -4,6 +4,15 @@ _Org:_ **Innovaciones MADFAM**
 _Product:_ **Sim4D** – Web-first, node-based parametric CAD
 _Status:_ Updated 2025-11-18 · Maintainer: Core Platform Team
 
+> [!WARNING]
+> **Stale document (noted 2026-07-04, RFC 0024 P3).** This roadmap has not
+> been substantively revised since **2025-11-18**; every date, score, and
+> "where we are today" claim below should be read as of that date, not the
+> present. In particular, its "production-ready with A- grade" framing
+> conflicts with the repository's current **alpha** status (see the README
+> "Current status" section, which is authoritative). Timelines for Horizons
+> A+ have not been re-baselined.
+
 > This roadmap reflects the current, shipping reality of the codebase as of November 2025, updated based on comprehensive audit findings. **MAJOR UPDATE (2025-11-18)**: Horizon 0 security work completed ahead of schedule - platform is now production-ready with A- grade (87/100). Platform has achieved zero security vulnerabilities and comprehensive security implementation. Recent critical bug fixes (double node placement, Vite worker import) have been successfully completed. Current focus shifts to Horizon A (Geometry Hardening) and strategic positioning decision. Timelines are indicative; execution depends on resourcing and addressing audit-identified priorities.
 
 ---


### PR DESCRIPTION
## Summary

RFC 0024 P3.2 congruency correction. The README claimed **"alpha"** (title line) and **"Production Ready · Stable API"** (Status section) at the same time, and the roadmap has been stale since 2025-11-18.

Verified against the tree on 2026-07-04 before writing:

- **Status reconciled to alpha**, with a dated "Current status (verified 2026-07-04)" section backed by evidence: 15 packages + 2 apps, ~4,800 tracked files, ~1,000 test/spec files, real pre-compiled OCCT.wasm binaries in `packages/engine-occt/wasm/` (web/single-thread/Node) backing Studio and CLI, 11 GitHub Actions workflows. Known gaps that keep it alpha are listed (disabled ~1.8k generated node catalogue, failing collaboration-package typecheck, incomplete collaboration/marketplace/plugin features, no API stability guarantee).
- The detailed 2025-11 engineering snapshot is **kept** but explicitly labeled as the last snapshot, not present-tense fact.
- "WASM binaries are production-ready" reworded: the binaries are pre-compiled and verified; that is not a product-readiness claim.
- **Broken link fixed:** `docs/product/ROADMAP.md` → `docs/project/ROADMAP.md`; roadmap references now carry its 2025-11-18 date.
- **Roadmap dated:** `docs/project/ROADMAP.md` now opens with a stale-document warning (noted 2026-07-04) that all scores/claims read as of 2025-11-18 and that the README Current status is authoritative; its "production-ready A-" framing conflicts with the alpha status.

Vision and reference content preserved; only status/readiness claims corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoTA2XopaT23M7wkt92mcX

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoTA2XopaT23M7wkt92mcX)_