### PR TITLE
ci(dependabot): consolidate npm sub-directory configs into the root entry

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,30 @@ version: 2
 
 updates:
   # ═══════════════════════════════════════════════════════════════════════════
-  # NPM Dependencies (Root & Monorepo Packages)
+  # NPM Dependencies — the WHOLE pnpm workspace, from the root
+  #
+  # ┌─────────────────────────────────────────────────────────────────────────┐
+  # │ SINGLE-LOCKFILE WORKSPACE: declare npm updates for '/' ONLY.            │
+  # │ Never add a per-app or per-package npm entry.                          │
+  # └─────────────────────────────────────────────────────────────────────────┘
+  #
+  # /pnpm-lock.yaml is the only lockfile in this repo and it covers every member
+  # of pnpm-workspace.yaml (apps/*, packages/*).
+  #
+  # Dependabot treats each configured `directory` as an independent project.
+  # From a sub-directory it finds that directory's package.json and no lockfile
+  # beside it, so it edits the manifest and never touches /pnpm-lock.yaml. The
+  # resulting PR is unmergeable on arrival: every gate here begins with
+  # `pnpm install --frozen-lockfile` (ci.yml, test.yml, e2e-tests.yml,
+  # security-scan.yml, test-docker.yml, nightly-cli.yml) and dies with
+  # ERR_PNPM_OUTDATED_LOCKFILE. No rebase can repair it — the config that
+  # produced the PR is incapable of producing a lockfile.
+  #
+  # The root entry below updates the member manifests AND the lockfile in one
+  # commit, which is the only shape that can go green here.
   # ═══════════════════════════════════════════════════════════════════════════
 
-  # Root package.json
+  # Root package.json + every apps/* and packages/* workspace member
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
@@ -65,56 +85,13 @@ updates:
     # assignees:
     #   - "lead-developer"
 
-    # Ignore specific dependencies (if needed)
-    ignore:
-      # Example: Ignore major version updates for stable packages
-      # - dependency-name: "react"
-      #   update-types: ["version-update:semver-major"]
-
-  # Studio app
-  - package-ecosystem: 'npm'
-    directory: '/apps/studio'
-    schedule:
-      interval: 'weekly'
-      day: 'monday'
-      time: '03:00'
-    open-pull-requests-limit: 5
-    commit-message:
-      prefix: 'deps(studio)'
-    labels:
-      - 'dependencies'
-      - 'studio'
-      - 'automated'
-
-  # Marketing app
-  - package-ecosystem: 'npm'
-    directory: '/apps/marketing'
-    schedule:
-      interval: 'weekly'
-      day: 'monday'
-      time: '03:30'
-    open-pull-requests-limit: 5
-    commit-message:
-      prefix: 'deps(marketing)'
-    labels:
-      - 'dependencies'
-      - 'marketing'
-      - 'automated'
-
-  # Engine Core
-  - package-ecosystem: 'npm'
-    directory: '/packages/engine-core'
-    schedule:
-      interval: 'weekly'
-      day: 'monday'
-      time: '04:00'
-    open-pull-requests-limit: 5
-    commit-message:
-      prefix: 'deps(engine-core)'
-    labels:
-      - 'dependencies'
-      - 'engine-core'
-      - 'automated'
+    # Ignore specific dependencies (if needed) — add an `ignore:` key here with
+    # real rules when one is needed. It is deliberately absent rather than
+    # present-and-empty, because a null `ignore:` is not a valid rule list.
+    # Example:
+    #   ignore:
+    #     - dependency-name: "react"
+    #       update-types: ["version-update:semver-major"]
 
   # ═══════════════════════════════════════════════════════════════════════════
   # GitHub Actions


### PR DESCRIPTION
## Three npm configs here can only ever produce unmergeable PRs

`.github/dependabot.yml` declared **four** npm update configs: the repo root plus
`/apps/studio`, `/apps/marketing` and `/packages/engine-core`.

This repo is a **single-lockfile pnpm workspace**. `/pnpm-lock.yaml` is the only
lockfile and it covers all fourteen members of `pnpm-workspace.yaml`
(`apps/*`, `packages/*`) — including all three of those directories.

Dependabot treats each configured `directory` as an **independent project**. From a
sub-directory it finds that directory's `package.json` and no lockfile beside it, so
**it edits the manifest and never touches `/pnpm-lock.yaml`.** The resulting PR is
born with a manifest/lockfile disagreement and can never go green: every gate in
this repo opens with `pnpm install --frozen-lockfile` — `ci.yml` (×5), `test.yml`
(×5), `e2e-tests.yml` (×3), `security-scan.yml` (×3), `test-docker.yml`,
`nightly-cli.yml` — and dies with `ERR_PNPM_OUTDATED_LOCKFILE`. **No rebase can
repair such a PR**, because the config that produced it is incapable of producing a
lockfile. The next scheduled run just makes another one.

### Evidence

The defect was proven twice today, independently, in sibling repos:

- **madfam-site, 8-for-8.** The single PR from the ROOT config (#263) changed 6
  manifests **plus `pnpm-lock.yaml`** and passed all four gates. The seven from
  sub-directory configs each changed exactly one `package.json`, carried no
  lockfile, and failed all four — CI, Quality Gates, Security Audit, PR Checks,
  every workflow whose first real step is the frozen install. CodeQL passed on those
  same commits: it is the one workflow that does not run that install. Fix:
  madfam-site#264.
- **dhanam #724** changes only `apps/api/package.json`, carries no lockfile, and
  fails `CI`, `Lint & Type Check` and `Test Coverage`. Its `Validate Lockfile` job
  prints `ERR_PNPM_OUTDATED_LOCKFILE ... pnpm-lock.yaml is not up to date with
  <ROOT>/apps/api/package.json` verbatim. That one sub-directory config produced 10
  PRs and **merged zero**.

**This repo's own history corroborates it from the other side.** Every npm PR
Dependabot has ever opened here came from the **root** config — branches like
`dependabot/npm_and_yarn/production-dependencies-*`,
`development-dependencies-*`, `multi-*`, `three-0.181.1` — and several of those
**merged** (#7, #8, #9, #10). The three sub-directory configs have produced
**zero** PRs in the repo's entire history: there is no
`dependabot/npm_and_yarn/apps/studio/*` branch, nor for `apps/marketing` or
`packages/engine-core`. One config shape works here and has a merge record; the
other has never delivered anything, and by construction never could.

## What changed

`.github/dependabot.yml` only. **6 update entries → 3.**

Removed the `/apps/studio`, `/apps/marketing` and `/packages/engine-core` npm
entries. The root `/` entry already covers all three workspaces *and* the lockfile,
in a single commit.

### What the removed entries carried

**Nothing was silently dropped, because there was nothing to drop:**

| Removed entry | `groups` | `ignore` |
|---|---|---|
| `/apps/studio` | *none declared* | *none declared* |
| `/apps/marketing` | *none declared* | *none declared* |
| `/packages/engine-core` | *none declared* | *none declared* |

Verified by parsing the before/after YAML, not by reading. The root entry's three
groups — `security-critical`, `production-dependencies`, `development-dependencies`
— are unchanged and now apply to those three workspaces uniformly, which they did
not before.

Worth naming, since it is the second half of this defect: **sub-directory configs do
not inherit the root config's `ignore` rules.** In madfam-site that was the sole
reason a deliberately-opted-out `next` major was raised at all. There was no
`ignore` rule to lose here — but consolidating removes the possibility.

### Where the removed entries disagreed with the root, the root wins

| Setting | Removed sub-directory entries | Root entry (kept) |
|---|---|---|
| `commit-message.prefix` | `deps(studio)` / `deps(marketing)` / `deps(engine-core)` | **`deps`**, with `prefix-development: deps-dev`, `include: scope` |
| `labels` | `dependencies`, `automated` + `studio`/`marketing`/`engine-core` | **`dependencies`, `automated`** |
| `open-pull-requests-limit` | 5 | **10** |
| `schedule` | monday 03:00 / 03:30 / 04:00 | **monday 02:00 UTC** |

The per-workspace commit prefixes and labels cannot survive consolidation: a
root-config PR spans several workspaces at once, so a single workspace's prefix or
label would be wrong on it. `versioning-strategy: increase` and
`allow: [dependency-type: all]` on the root entry are unchanged.

### One small schema repair

The root entry had an `ignore:` key whose entire body was commented-out examples, so
it parsed as **null** — not a valid rule list. The key is removed and the example
kept as a plain comment. This changes no behaviour; it just stops the file from
carrying a malformed key.

`github-actions` and `docker` entries are **untouched** — they are not affected by
this defect. The parsed before/after diff confirms both are identical.

## Verification

GitHub Actions is in a major outage (incident `qcvjkzcs7j74`): runs are queued,
cancelled or never created, and `gh pr checks` / `statusCheckRollup` omit queued
runs and will falsely report "0 pending". So this is local verification, not a CI
signal.

There is no official local validator for `dependabot.yml`, so the bar is a parse
check plus a careful read against GitHub's documented schema. What I checked:

- **YAML parses** (`yaml.safe_load`), 164 lines.
- **Schema**: `version: 2`; every entry has a `package-ecosystem` from the documented
  ecosystem set and a `directory` starting with `/`; no unknown entry keys; every
  `schedule.interval` valid; `open-pull-requests-limit` an integer; every group
  declares at least one matcher; no `ignore` key present-but-null; no duplicate
  (ecosystem, directory) pair.
- **Every configured directory exists** in the repo.
- **The invariant this PR is about**, checked against the real repo layout and
  against the actual `importers:` list in `/pnpm-lock.yaml` (so workspace membership
  is read from the lockfile, not assumed): for every npm entry, a lockfile sits
  beside the manifest. **Before: 3 of 4 npm entries violated it. After: 0 of 1.**
- **Semantic before/after diff** of the parsed YAML: exactly three entries removed,
  none added, the root npm entry's groups unchanged, and the `github-actions` and
  `docker` entries identical.
- `npx prettier --check .github/dependabot.yml` → clean.

No workflow, test or gate was weakened, disabled or skipped. Nothing outside
`.github/dependabot.yml` is touched.

## Follow-up

**Open PRs produced by a sub-directory npm config in this repo: none.** This repo
currently has no open PRs at all, and the three sub-directory configs never produced
one. Nothing needs closing here.

For completeness, since it applies wherever this defect is fixed: **existing
sub-directory PRs remain unmergeable and cannot be salvaged by rebase** — the branch
will still be missing a lockfile afterwards. They must be **closed** so Dependabot
reopens the same bumps from the root config, this time with `pnpm-lock.yaml`
included. In dhanam that is #724; in madfam-site it is the seven PRs listed on
madfam-site#264.

### Unverified

The root entry's `security-critical` group declares `update-types: ['security']`.
`security` is not one of the documented values for a group's `update-types`
(`major` / `minor` / `patch`), yet the file is evidently accepted and the other two
groups demonstrably work — the merged PRs above are named after them. I left it
exactly as-is: it is pre-existing, it is not part of this defect, and changing group
semantics is not what this PR is for. Flagging it so it is on the record.
